### PR TITLE
ignore failures on clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ doc:	$(HEADERS) Doxyfile README.md
 	doxygen Doxyfile
 
 clean:
-	rm -r doc
+	-rm -r doc
 	make -C examples clean
 
 .PHONY: all examples clean

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -43,7 +43,7 @@ FLAGS.gpb += -O3 -DDEBUG -DBENCH -lprofiler
 all bench debug optdebug profile optprofile: $$(addsuffix $$(SFX),$$(PROGS))
 
 clean:
-	rm -f $(ALLTARGETS)
+	-rm -f $(ALLTARGETS)
 
 .PHONY: all clean bench debug optdebug profile optprofile
 


### PR DESCRIPTION
Failures in `rm` should not fail the make target as generally they imply that the files being removed do not exist in the first place.